### PR TITLE
Update port name

### DIFF
--- a/templates/cloudwatch-aggregator.yml
+++ b/templates/cloudwatch-aggregator.yml
@@ -90,7 +90,7 @@ objects:
             failureThreshold: 3
             httpGet:
               path: /ping
-              port: cloudwatch-aggregator
+              port: cwa
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 10
@@ -99,13 +99,13 @@ objects:
           name: cloudwatch-aggregator
           ports:
           - containerPort: 8080
-            name: cloudwatch-aggregator
+            name: cwa
             protocol: TCP
           readinessProbe:
             failureThreshold: 3
             httpGet:
               path: /ping
-              port: cloudwatch-aggregator
+              port: cwa
               scheme: HTTP
             initialDelaySeconds: 15
             periodSeconds: 10


### PR DESCRIPTION
There is a 15 character limit on container port names [1], so this abbreviates
that value.

[1] https://github.com/kubernetes/kubernetes/blob/b0bc8adbc2178e15872f9ef040355c51c45d04bb/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L331