### PR TITLE
[RHCLOUD-20966] Use ubi-minimal image in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM registry.access.redhat.com/ubi8/python-39
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 WORKDIR /usr/src/app
 COPY Pipfile* /usr/src/app/
 
-RUN pip install pipenv
+RUN microdnf install --disableplugin=subscription-manager --nodocs -y python39 tar gzip
+
+RUN pip3 install --upgrade pip
+RUN pip3 install pipenv
 RUN pipenv install --system --deploy --ignore-pipfile
 
 COPY . /usr/src/app/


### PR DESCRIPTION
According to suggestions in https://issues.redhat.com/browse/RHCLOUD-20966:
- set "ubi8/ubi-minimal" as the base image
- installing the version of python needed

There is build image in quay https://quay.io/repository/lpichler/cloudwatch-aggregator/manifest/sha256:16d5ec257bf0078e33f14f24f590c8c95d5882179bec1dd43d566c1774b380d8?tab=vulnerabilities - and there is visible there are not high vulnerabilities detected already.


### Links
- https://issues.redhat.com/browse/RHCLOUD-20966
