### PR TITLE
Add CA with a configMap conditionally

### DIFF
--- a/templates/clowdapp.yml
+++ b/templates/clowdapp.yml
@@ -71,6 +71,15 @@ objects:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
+        volumes:
+        - name: trusted-certs-volume
+          configMap:
+            optional: true
+            name: trusted-certs
+        volumeMounts:
+        - name: trusted-certs-volume
+          mountPath: /etc/ssl/certs/${TRUSTED_CERT_FILENAME}
+          subPath: ${TRUSTED_CERT_FILENAME}
         resources:
           limits:
             cpu: ${CPU_LIMIT}
@@ -157,3 +166,6 @@ parameters:
 - description: Flag to enable Splunk debug logs
   name: SPLUNK_DEBUG
   value: "false"
+- description: Sub path / filename to mount the trusted cert configMap
+  name: TRUSTED_CERT_FILENAME
+  value: "placeholder.pem"


### PR DESCRIPTION
This will allow a CA to be added via a `trusted-certs` configMap (optionally), which will add the CA to `/etc/ssl/certs/${TRUSTED_CERT_FILENAME}` based on the configMap key/value.

In the event the configMap doesn't exist, this will not require the volume, but will create a superfluous empty dir in `/etc/ssl/certs/` - long term we may want to consider an alternate conditional approach, but since mounts aren't optional this may be required to get a custom CA in environments where it's required.