### PR TITLE
Use raw request data

### DIFF
--- a/app/log.py
+++ b/app/log.py
@@ -45,7 +45,7 @@ def log(log_stream):
     validate_log_stream(log_stream)
     logger = logging.getLogger(log_stream)
     add_log_handlers(log_stream, logger)
-    logger.info(request.get_json(force=True))
+    logger.info(request.get_data(as_text=True))
     return {"status": "accepted"}, 202
 
 

--- a/templates/clowdapp.yml
+++ b/templates/clowdapp.yml
@@ -166,7 +166,7 @@ parameters:
   value: "true"
 - description: Flag to format Splunk logs as JSON
   name: SPLUNK_FORMAT_JSON
-  value: "true"
+  value: "false"
 - description: Flag to enable Splunk debug logs
   name: SPLUNK_DEBUG
   value: "false"


### PR DESCRIPTION
For Splunk, we need to send the raw JSON string in order for it to be consumed
correctly, otherwise the object will end up being encoded incorrectly.
This change ensures that will happen.

For Watchtower (CloudWatch), existing functionality will be preserved because of
the fact that the library will check to see if the payload is a dictionary before
attemtping to convert the object back to a string [1] which in this case will now
be a no-op.

[1] https://github.com/kislyuk/watchtower/blob/develop/watchtower/__init__.py#L134-L135