### PR TITLE
updated values for memory limit and request

### DIFF
--- a/templates/clowdapp.yml
+++ b/templates/clowdapp.yml
@@ -125,10 +125,10 @@ parameters:
   value: quay.io/cloudservices/cloudwatch-aggregator
   required: true
 - name: MEMORY_LIMIT
-  value: 1Gi
+  value: 500Mi
   required: true
 - name: MEMORY_REQUEST
-  value: 750Mi
+  value: 250Mi
   required: true
 - name: CPU_LIMIT
   value: 500m


### PR DESCRIPTION
based on long-term observation, we can reduce the values for memory limit and request
https://grafana.stage.devshift.net/d/HXbU7G1Iz/aandm-resources-health?orgId=1&from=now-30d&to=now&var-Datasource=crcp01ue1-prometheus
![image](https://github.com/RedHatInsights/cloudwatch-aggregator/assets/89980168/1959514c-036a-4306-a295-6e7d5ec1fd39)
