### PR TITLE
deploy via deployment object

### DIFF
--- a/templates/cloudwatch-aggregator.yml
+++ b/templates/cloudwatch-aggregator.yml
@@ -55,7 +55,7 @@ parameters:
   name: SPLUNK_DEBUG
   value: "false"
 objects:
-- apiVersion: apps.openshift.io/v1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     annotations:
@@ -68,18 +68,13 @@ objects:
     replicas: ${{REPLICAS}}
     revisionHistoryLimit: 10
     selector:
-      app: cloudwatch-aggregator
-      deploymentconfig: cloudwatch-aggregator
+      matchLabels:
+        app: cloudwatch-aggregator
     strategy:
-      activeDeadlineSeconds: 21600
-      resources: {}
-      rollingParams:
-        intervalSeconds: 1
+      type: RollingUpdate
+      rollingUpdate:
         maxSurge: 25%
         maxUnavailable: 25%
-        timeoutSeconds: 600
-        updatePeriodSeconds: 1
-      type: Rolling
     template:
       metadata:
         creationTimestamp: null

--- a/templates/cloudwatch-aggregator.yml
+++ b/templates/cloudwatch-aggregator.yml
@@ -59,10 +59,10 @@ objects:
   kind: Deployment
   metadata:
     annotations:
-      email: Cloud-Platform-Infra@redhat.com
+      email: platform-accessmanagement@redhat.com
     labels:
       app: cloudwatch-aggregator
-      owner: platform-infra
+      owner: platform-accessmanagement
     name: cloudwatch-aggregator
   spec:
     replicas: ${{REPLICAS}}

--- a/templates/cloudwatch-aggregator.yml
+++ b/templates/cloudwatch-aggregator.yml
@@ -56,7 +56,7 @@ parameters:
   value: "false"
 objects:
 - apiVersion: apps.openshift.io/v1
-  kind: DeploymentConfig
+  kind: Deployment
   metadata:
     annotations:
       email: Cloud-Platform-Infra@redhat.com


### PR DESCRIPTION
update default deployment to use deployment object instead of deploymentconfig

testing: successfully deployed to ephemeral and able to ping the service