### PR TITLE
Revert "migrate the base images to the ubi9"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 WORKDIR /usr/src/app
 COPY Pipfile* /usr/src/app/
 
-RUN microdnf install --disableplugin=subscription-manager --nodocs -y python39 tar gzip pip
+RUN microdnf install --disableplugin=subscription-manager --nodocs -y python39 tar gzip
 
 RUN pip3 install --upgrade pip
 RUN pip3 install pipenv


### PR DESCRIPTION
This reverts commit ce309f2060d42bc8a1fe9d42e6c08df4d39458e0. 
Because of the FEDRAMP requirement we need to migrate back to the ubi8