### PR TITLE
[RHCLOUD-32031] add .dockerignore in the repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Ignore everything
+*
+
+# ... except for
+!app/
+!Pipfile
+!Pipfile.lock
+!run-server.sh


### PR DESCRIPTION
[RHCLOUD-32031](https://issues.redhat.com/browse/RHCLOUD-32031)

one of recommendations in [Credential Leak Self Assessment](https://docs.google.com/document/d/1IsX7NmMnWPcuOseyjjUj_T9VjBXx7p3UjWs5eNpDHyI/edit?tab=t.0) document is to add `.dockerignore` file into repository