### PR TITLE
[RHCLOUD-36968] dependencies update via 'pipenv lock'

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -34,27 +34,27 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:5ef7166fe5060637b92af8dc152cd7acecf96b3fc9c5456706a886cadb534391",
-                "sha256:fc8001519c8842e766ad3793bde3fbd0bb39e821a582fc12cf67876b8f3cf7f1"
+                "sha256:9f9bf72d92f7fdd546b974ffa45fa6715b9af7f5c00463e9d0f6ef9c95efe0c2",
+                "sha256:c94fc8023caf952f8740a48fc400521bba167f883cfa547d985c05fda7223f7a"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.35.78"
+            "version": "==1.35.84"
         },
         "botocore": {
             "hashes": [
-                "sha256:41c37bd7c0326f25122f33ec84fb80fc0a14d7fcc9961431b0e57568e88c9cb5",
-                "sha256:6905036c25449ae8dba5e950e4b908e4b8a6fe6b516bf61e007ecb62fa21f323"
+                "sha256:b4dc2ac7f54ba959429e1debbd6c7c2fb2349baa1cd63803f0682f0773dbd077",
+                "sha256:f86754882e04683e2e99a6a23377d0dd7f1fc2b2242844b2381dbe4dcd639301"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.35.78"
+            "version": "==1.35.84"
         },
         "certifi": {
             "hashes": [
-                "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8",
-                "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"
+                "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56",
+                "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2024.8.30"
+            "version": "==2024.12.14"
         },
         "charset-normalizer": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 -i https://pypi.org/simple
 app-common-python==0.2.7
 blinker==1.9.0; python_version >= '3.9'
-boto3==1.35.78; python_version >= '3.8'
-botocore==1.35.78; python_version >= '3.8'
-certifi==2024.8.30; python_version >= '3.6'
+boto3==1.35.84; python_version >= '3.8'
+botocore==1.35.84; python_version >= '3.8'
+certifi==2024.12.14; python_version >= '3.6'
 charset-normalizer==3.4.0; python_full_version >= '3.7.0'
 click==8.1.7; python_version >= '3.7'
 flask==3.1.0; python_version >= '3.9'


### PR DESCRIPTION
[RHCLOUD-36968](https://issues.redhat.com/browse/RHCLOUD-36968)

additionally this PR will create image with last ubi8-minimal base image and fix vulnerability in `bzip2-libs`: https://access.redhat.com/security/cve/cve-2019-12900
```
NAME        INSTALLED     FIXED-IN           TYPE  VULNERABILITY   SEVERITY 
bzip2-libs  1.0.6-26.el8  0:1.0.6-27.el8_10  rpm   CVE-2019-12900  Low
```