### PR TITLE
[RHCLOUD-37661] remove pipenv installation from the pre-commit github action - it is not needed anymore

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,8 +17,5 @@ jobs:
       with:
         python-version: '3.9'
 
-    - name: Install Pipenv
-      run: pip install pipenv
-
     - name: Run Pre-Commit
       uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
[RHCLOUD-37661](https://issues.redhat.com/browse/RHCLOUD-37661)

I forgot to remove it here https://github.com/RedHatInsights/cloudwatch-aggregator/pull/143