### PR TITLE
[RHCLOUD-295651] Add splunk env vars needed for splunk logs 

### DIFF
--- a/templates/cloudwatch-aggregator.yml
+++ b/templates/cloudwatch-aggregator.yml
@@ -105,8 +105,6 @@ objects:
             value: ${SPLUNK_FORMAT_JSON}
           - name: SPLUNK_DEBUG
             value: ${SPLUNK_DEBUG}
-          - name: SPLUNK_FORMAT_JSON
-            value: ${SPLUNK_FORMAT_JSON}
           - name: SPLUNK_SOURCE_TYPE
             value: ${SPLUNK_SOURCE_TYPE}
           - name: SPLUNK_TOKEN

--- a/templates/cloudwatch-aggregator.yml
+++ b/templates/cloudwatch-aggregator.yml
@@ -50,7 +50,9 @@ parameters:
   value: "true"
 - description: Flag to format Splunk logs as JSON
   name: SPLUNK_FORMAT_JSON
-  value: "true"
+  value: "false"
+- description: Source type for logs to splunk
+  name: SPLUNK_SOURCE_TYPE
 - description: Flag to enable Splunk debug logs
   name: SPLUNK_DEBUG
   value: "false"
@@ -103,6 +105,10 @@ objects:
             value: ${SPLUNK_FORMAT_JSON}
           - name: SPLUNK_DEBUG
             value: ${SPLUNK_DEBUG}
+          - name: SPLUNK_FORMAT_JSON
+            value: ${SPLUNK_FORMAT_JSON}
+          - name: SPLUNK_SOURCE_TYPE
+            value: ${SPLUNK_SOURCE_TYPE}
           - name: SPLUNK_TOKEN
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
Context: 
Currently, there are 400 bad request errors appearing within the stage pods because of the weird escapes when payload is created for the splunk logs. 
- Fix found by @coderbydesign to send request with json format, so adding splunk env var SPLUNK_FORMAT_JSON and SPLUNK_SOURCE_TYPE in order to try to fix the 400 request issue


Link to JIRA: https://issues.redhat.com/browse/RHCLOUD-29651