### PR TITLE
remove obsolete field 'version'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   web:
     build: .


### PR DESCRIPTION

```
WARN[0000] /Users/petracihalova/Documents/projects/cloudwatch-aggregator/docker-compose.yml: `version` is obsolete 
```