### PR TITLE
[RHCLOUD-41021] add github action Labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,9 @@
+# Docs: https://github.com/marketplace/actions/labeler
+
+# Add "security-compliance" label to any PR that is opened against the "security-compliance" branch
+security-compliance:
+ - base-branch: 'security-compliance'
+
+# Add "bot" label to any PR where the head branch name starts with "konflux" or "dependabot"
+bot:
+ - head-branch: ['^konflux/', '^dependabot/']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
[RHCLOUD-41021](https://issues.redhat.com/browse/RHCLOUD-41021)

github action will add "bot" label automatically on every PR created by konflux bot or dependabot, we can set new rules in the future to add labels on our PRs if needed via config in `.github/labeler.yml`