### PR TITLE
update renovate config to disable automatic locks refresh

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "baseBranches": [
     "main"
-  ]
+  ],
+  "lockFileMaintenance": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
this config will disable locks refresh (= the Konflux PRs with regenerated `Pipfile.lock`)

why?

because now we are receiving quite lot of Konflux PRs with dependency updates and every PR contains locks refresh so we dont need extra PR with that refresh = less Konflux PRs & same output