### PR TITLE
Fix breaking change in watchtower

### DIFF
--- a/app/log.py
+++ b/app/log.py
@@ -84,11 +84,12 @@ def add_splunk_handler(logger):
 
 
 def add_cw_handler(log_stream, logger):
+    boto_client = session().client("logs")
     logger.addHandler(
         watchtower.CloudWatchLogHandler(
             log_group_name=AWS_LOG_GROUP,
             log_stream_name=log_stream,
-            boto3_session=session(),
+            boto3_client=boto_client,
         )
     )
 


### PR DESCRIPTION
There was a breaking change [1] somewhat hidden in the release notes for `2.0.0` [2] which prevents usage of session objects in the handler directly. We can still use our session to generate a client [3] for the handler. This resolves the issue from the original major version bump [4].

[1] https://github.com/kislyuk/watchtower/compare/v1.0.6...v2.0.0#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fL72-L75
[2] https://github.com/kislyuk/watchtower/releases/tag/v2.0.0
[3] https://boto3.amazonaws.com/v1/documentation/api/latest/guide/session.html#custom-session
[4] https://github.com/RedHatInsights/cloudwatch-aggregator/pull/244