### PR TITLE
chore: update UBI9 base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1780378819
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1781496742
 
 LABEL name="cloudwatch-aggregator" \
       summary="CloudWatch Aggregator - Batch Logging Service" \


### PR DESCRIPTION
## Summary

Update UBI9 container base images to latest available versions from Red Hat Container Catalog.

## Changes

| Dockerfile | Image | Old Tag | New Tag | Health |
|------------|-------|---------|---------|--------|
| `Dockerfile` | `ubi9/ubi-minimal` | `9.8-1780378819` | `9.8-1781496742` | A |

## Motivation

- Keep base images current with security patches
- Maintain compliance with container health requirements
- Reduce technical debt from outdated base images

## Verification

- [ ] Container builds succeed locally
- [ ] CI/CD pipeline passes
- [ ] Application functions correctly with updated base

## References

- [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/)
- Latest tags verified via Pyxis API

## Test Plan

1. Verify container builds complete successfully
2. Run application smoke tests
3. Confirm no regression in functionality

🤖 Generated with [Claude Code](https://claude.ai/code)
